### PR TITLE
feat: support env-driven worker roster for localhost

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -1,0 +1,137 @@
+"""Utilities for describing and loading the runtime environment."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from importlib import import_module, util
+from pathlib import Path
+
+
+def _resolve_dotenv_loader():
+    """Return ``dotenv.load_dotenv`` when available, otherwise a no-op."""
+
+    spec = util.find_spec("dotenv")
+    if spec is None:
+        def _noop(*_args, **_kwargs):  # pragma: no cover - exercised when dependency absent
+            return False
+
+        return _noop
+
+    module = import_module("dotenv")
+    return getattr(module, "load_dotenv")
+
+
+load_dotenv = _resolve_dotenv_loader()
+
+
+class RuntimeEnvironment(str, Enum):
+    """Supported execution environments for the trading bot."""
+
+    SANDBOX = "sandbox"
+    PAPER = "paper"
+    PRODUCTION = "production"
+
+    @classmethod
+    def from_value(cls, value: str | None) -> "RuntimeEnvironment":
+        """Parse an environment name and fall back to ``SANDBOX`` when unknown."""
+
+        if not value:
+            return cls.SANDBOX
+
+        normalized = value.strip().lower()
+        for member in cls:
+            if normalized == member.value:
+                return member
+
+        # Preserve backwards compatibility by accepting shorthand tokens.
+        aliases = {
+            "dev": cls.SANDBOX,
+            "development": cls.SANDBOX,
+            "test": cls.PAPER,
+            "staging": cls.PAPER,
+            "prod": cls.PRODUCTION,
+            "live": cls.PRODUCTION,
+        }
+        return aliases.get(normalized, cls.SANDBOX)
+
+
+@dataclass(frozen=True)
+class EnvironmentConfig:
+    """Container describing execution characteristics for the application."""
+
+    name: RuntimeEnvironment
+    alpaca_base_url: str
+    enable_order_execution: bool
+
+
+def _load_dotenv_file() -> None:
+    """Load environment variables from ``.env`` if present.
+
+    ``TRADING_DOTENV_FILE`` can be used to point to a non-standard file path.
+    The loader runs once per interpreter lifecycle to avoid repeated disk IO
+    and to guarantee the settings are available before other modules import
+    configuration.
+    """
+
+    candidate = os.getenv("TRADING_DOTENV_FILE")
+    if candidate:
+        path = Path(candidate)
+        if path.exists():
+            load_dotenv(dotenv_path=path)
+            return
+
+    # Default to project root ``.env``. ``load_dotenv`` safely no-ops if the
+    # file is missing which keeps production environments uncluttered.
+    load_dotenv()
+
+
+_load_dotenv_file()
+
+
+DEFAULT_ALPACA_URLS: dict[RuntimeEnvironment, str] = {
+    RuntimeEnvironment.SANDBOX: "https://paper-api.alpaca.markets",
+    RuntimeEnvironment.PAPER: "https://paper-api.alpaca.markets",
+    RuntimeEnvironment.PRODUCTION: "https://api.alpaca.markets",
+}
+
+
+@lru_cache(maxsize=1)
+def get_environment_config() -> EnvironmentConfig:
+    """Return the cached ``EnvironmentConfig`` for the current process."""
+
+    runtime = RuntimeEnvironment.from_value(os.getenv("TRADING_RUNTIME_ENV"))
+
+    # Never hard-code API hosts in multiple places. Users can still override
+    # ``APCA_API_BASE_URL`` explicitly when they need a custom endpoint.
+    alpaca_base_url = os.getenv("APCA_API_BASE_URL", DEFAULT_ALPACA_URLS[runtime])
+
+    # Order execution remains opt-in for sandbox and paper environments.
+    raw_execution_flag = os.getenv("TRADING_ENABLE_EXECUTION")
+    if raw_execution_flag is None:
+        enable_order_execution = runtime is RuntimeEnvironment.PRODUCTION
+    else:
+        enable_order_execution = raw_execution_flag.strip().lower() in {"1", "true", "yes", "on"}
+
+    return EnvironmentConfig(
+        name=runtime,
+        alpaca_base_url=alpaca_base_url,
+        enable_order_execution=enable_order_execution,
+    )
+
+
+def is_sandbox() -> bool:
+    """Convenience helper to test whether the runtime is sandbox-like."""
+
+    env = get_environment_config()
+    return env.name in {RuntimeEnvironment.SANDBOX, RuntimeEnvironment.PAPER}
+
+
+__all__ = [
+    "EnvironmentConfig",
+    "RuntimeEnvironment",
+    "get_environment_config",
+    "is_sandbox",
+]

--- a/docs/local_runtime.md
+++ b/docs/local_runtime.md
@@ -1,0 +1,54 @@
+# Local Runtime Guide
+
+This guide focuses on running the unified trading service on your workstation so you can verify behaviour against the Alpaca paper-trading API before deploying to remote environments.
+
+## 1. Bootstrap dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+npm install  # if you plan to run the React frontend build or Playwright tests
+```
+
+Install the optional dependencies that power the live integrations:
+
+- `alpaca-trade-api` for market data and order routing.
+- `python-dotenv` to automatically load the environment variables listed below.
+
+## 2. Configure environment variables
+
+Create a `.env` file in the project root to keep runtime configuration DRY:
+
+```ini
+TRADING_RUNTIME_ENV=sandbox
+APCA_API_KEY_ID=your-paper-key
+APCA_API_SECRET_KEY=your-paper-secret
+APCA_API_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_AUTH_FILE=AUTH/authAlpaca.txt
+
+# Background worker roster for localhost usage
+TRADING_SERVICE_BACKGROUND_WORKERS=update_cache,crypto_scanner,crypto_scalping_trader
+```
+
+Adjust the roster to experiment with different combinations of background jobs. When the variable is omitted the service will execute every registered worker. Setting it to an empty string disables all workers, which is helpful when you want to load the UI without touching Alpaca.
+
+## 3. Launch the unified service
+
+```bash
+uvicorn unified_trading_service_with_frontend:app --reload --port 9000
+```
+
+The lifespan hook now prints the workers that have been activated so you can confirm the localhost runtime matches your `.env` expectations.
+
+If you only want to validate API connectivity without the React bundle, run the Python module directly:
+
+```bash
+python unified_trading_service_with_frontend.py
+```
+
+## 4. Recommended next steps
+
+- Use `tests/unit/config/test_service_settings.py` to verify configuration parsing.
+- Consider running the service inside `poetry run` or `pipenv run` once you migrate dependency management to those tools for consistent environments across teammates.
+- When you are ready to move beyond localhost, promote the same container configuration to your sandbox account and reuse the `.env` keys via your preferred secret manager.

--- a/docs/sandbox_deployment.md
+++ b/docs/sandbox_deployment.md
@@ -1,0 +1,87 @@
+# Sandbox & GCP Deployment Playbook
+
+This guide explains how to run the trading bot in a controlled paper-trading
+sandbox, then promote the exact same artefact into Google Cloud Platform (GCP)
+services without drifting from DRY principles.
+
+> ⚠️ **Live trading is intentionally disabled by default.** You must opt-in by
+> setting `TRADING_ENABLE_EXECUTION=1` and providing production Alpaca
+> credentials. Keep paper trading on until integration tests and manual sanity
+> checks are green.
+
+## 1. Local sandbox execution
+
+1. Copy `AUTH/authAlpaca.example.txt` (or request the template) to
+   `AUTH/authAlpaca.txt` and populate your paper trading keys. Keep the file out
+   of version control.
+2. Create a `.env` in the project root:
+
+   ```dotenv
+   TRADING_RUNTIME_ENV=sandbox
+   TRADING_ENABLE_EXECUTION=0
+   APCA_API_KEY_ID=your-paper-key
+   APCA_API_SECRET_KEY=your-paper-secret
+   ```
+
+3. Install dependencies and run the bot in read-only mode:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   python main.py
+   ```
+
+4. Inspect the logs; the startup banner now prints the runtime environment and a
+   reminder that order execution is disabled.
+
+## 2. Harden for real trading
+
+- Keep credentials in a dedicated secret manager (e.g. GCP Secret Manager) and
+  mount them at runtime. Never ship them inside container images.
+- Introduce end-to-end tests that verify order submission against Alpaca's
+  paper endpoint. Use feature flags to mock responses in CI to avoid rate
+  limits.
+- Implement health checks in FastAPI or Flask services that validate account
+  connectivity before the trading loop starts.
+
+## 3. GCP sandbox deployment
+
+1. **Build once** and reuse the same container image across stages:
+
+   ```bash
+   gcloud builds submit --tag gcr.io/PROJECT_ID/alpaca-bot:latest
+   ```
+
+2. **Provision Cloud SQL (optional)** for persistent state. Store the connection
+   string in Secret Manager and expose it via environment variables; do not
+   hardcode DSNs.
+
+3. **Deploy to Cloud Run** in paper mode:
+
+   ```bash
+   gcloud run deploy alpaca-sandbox \
+     --image gcr.io/PROJECT_ID/alpaca-bot:latest \
+     --region=us-central1 \
+     --set-env-vars TRADING_RUNTIME_ENV=sandbox,TRADING_ENABLE_EXECUTION=0 \
+     --set-secrets APCA_API_KEY_ID=alpaca-paper-key:latest,APCA_API_SECRET_KEY=alpaca-paper-secret:latest \
+     --max-instances=1
+   ```
+
+4. Use Cloud Scheduler to hit a dedicated `/health` endpoint every minute and
+   publish alerts to Cloud Monitoring when connectivity issues surface.
+
+5. Mirror the runtime configuration to a `staging` service before flipping
+   `TRADING_ENABLE_EXECUTION` to `1` in production. Review Cloud Audit Logs to
+   guarantee only intended principals can mutate deployment variables.
+
+## 4. Recommended next steps
+
+- Break the monolithic `unified_trading_service_with_frontend.py` into
+  dedicated FastAPI routers so Cloud Run cold starts stay small and your team
+  can deploy UI and trading logic independently.
+- Add contract tests for `config.service_settings.get_service_settings()` to
+  ensure future refactors keep environment mappings intact.
+- Introduce Terraform modules or Google Cloud Deploy pipelines so environment
+  promotion is declarative and reviewable instead of click-ops.
+

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from core.service_registry import get_service_registry, setup_core_services, cleanup_service_registry
 from config.unified_config import get_config
+from config.environment import get_environment_config
 from trading_bot import TradingBot
 from strategies.stoch_rsi_strategy import StochRSIStrategy
 from strategies.ma_crossover_strategy import MACrossoverStrategy
@@ -53,6 +54,14 @@ def main():
         # Setup logging
         setup_logging()
         logger.info("Starting Alpaca Trading Bot with unified architecture...")
+
+        env_config = get_environment_config()
+        logger.info("Runtime environment: %s", env_config.name.value)
+        if not env_config.enable_order_execution:
+            logger.warning(
+                "Order execution is disabled for this environment. Set TRADING_ENABLE_EXECUTION=1"
+                " if you intend to place live orders."
+            )
         
         # Setup core services
         logger.info("Initializing service registry...")

--- a/services/unified_trading/__init__.py
+++ b/services/unified_trading/__init__.py
@@ -1,0 +1,37 @@
+"""Helpers for the unified trading service runtime."""
+
+from .background_workers import (
+    BackgroundWorkerRegistry,
+    list_named_background_workers,
+    list_background_workers,
+    register_background_worker,
+    resolve_background_workers,
+    reset_background_workers,
+    set_background_workers,
+)
+from .state import (
+    QUOTE_SUFFIXES,
+    SessionMetrics,
+    TradingState,
+    manage_background_tasks,
+    refresh_scanner_symbols,
+    to_display_symbol,
+    to_scanner_symbol,
+)
+
+__all__ = [
+    "BackgroundWorkerRegistry",
+    "list_named_background_workers",
+    "QUOTE_SUFFIXES",
+    "list_background_workers",
+    "register_background_worker",
+    "resolve_background_workers",
+    "reset_background_workers",
+    "set_background_workers",
+    "SessionMetrics",
+    "TradingState",
+    "manage_background_tasks",
+    "refresh_scanner_symbols",
+    "to_display_symbol",
+    "to_scanner_symbol",
+]

--- a/services/unified_trading/background_workers.py
+++ b/services/unified_trading/background_workers.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Iterable, Tuple
+
+from .state import BackgroundWorker
+
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundWorkerRegistry:
+    """Registry for trading background workers.
+
+    The registry centralises worker enrollment so services can reuse the same
+    TaskGroup orchestration without modifying FastAPI entrypoints directly.
+    """
+
+    def __init__(self) -> None:
+        self._workers: "OrderedDict[str, BackgroundWorker]" = OrderedDict()
+
+    def register(
+        self,
+        worker: BackgroundWorker,
+        *,
+        name: str | None = None,
+    ) -> BackgroundWorker:
+        """Register a worker callable.
+
+        If a worker with the same name exists it will be replaced to avoid
+        duplicate execution while keeping registration idempotent.
+        """
+
+        worker_name = name or getattr(worker, "__name__", str(id(worker)))
+        self._workers[worker_name] = worker
+        return worker
+
+    def unregister(self, name: str) -> None:
+        """Remove a worker from the registry if present."""
+
+        self._workers.pop(name, None)
+
+    def clear(self) -> None:
+        """Remove all workers from the registry."""
+
+        self._workers.clear()
+
+    def list(self) -> Tuple[BackgroundWorker, ...]:
+        """Return the registered workers as an ordered tuple."""
+
+        return tuple(self._workers.values())
+
+    def items(self) -> Tuple[Tuple[str, BackgroundWorker], ...]:
+        """Return ``(name, worker)`` tuples preserving registration order."""
+
+        return tuple(self._workers.items())
+
+    def extend(self, workers: Iterable[BackgroundWorker]) -> None:
+        """Bulk register workers preserving order."""
+
+        for worker in workers:
+            self.register(worker)
+
+
+_registry = BackgroundWorkerRegistry()
+
+
+def register_background_worker(
+    worker: BackgroundWorker,
+    *,
+    name: str | None = None,
+) -> BackgroundWorker:
+    """Module-level helper to register a background worker."""
+
+    return _registry.register(worker, name=name)
+
+
+def list_background_workers() -> Tuple[BackgroundWorker, ...]:
+    """Return the currently registered workers."""
+
+    return _registry.list()
+
+
+def list_named_background_workers() -> Tuple[Tuple[str, BackgroundWorker], ...]:
+    """Return the registered workers alongside their names."""
+
+    return _registry.items()
+
+
+def reset_background_workers() -> None:
+    """Clear registered workers. Useful for tests."""
+
+    _registry.clear()
+
+
+def set_background_workers(workers: Iterable[BackgroundWorker]) -> None:
+    """Replace the registry content with the provided workers."""
+
+    _registry.clear()
+    _registry.extend(workers)
+
+
+def resolve_background_workers(
+    worker_names: Iterable[str] | None,
+) -> Tuple[BackgroundWorker, ...]:
+    """Return workers matching ``worker_names`` or all registered when ``None``.
+
+    Unknown worker names are ignored with a warning so misconfigurations do not
+    prevent the service from starting locally.
+    """
+
+    if worker_names is None:
+        return list_background_workers()
+
+    normalized = []
+    for name in worker_names:
+        stripped = name.strip()
+        if stripped:
+            normalized.append(stripped.lower())
+
+    if not normalized:
+        return tuple()
+
+    registered = {name.lower(): worker for name, worker in list_named_background_workers()}
+
+    missing = sorted({name for name in normalized if name not in registered})
+    if missing:
+        logger.warning(
+            "Unknown background workers requested via configuration: %s",
+            ", ".join(missing),
+        )
+
+    resolved = [registered[name] for name in normalized if name in registered]
+    return tuple(resolved)
+
+
+__all__ = [
+    "BackgroundWorkerRegistry",
+    "list_named_background_workers",
+    "list_background_workers",
+    "register_background_worker",
+    "reset_background_workers",
+    "set_background_workers",
+    "resolve_background_workers",
+]

--- a/services/unified_trading/state.py
+++ b/services/unified_trading/state.py
@@ -1,0 +1,189 @@
+"""State containers and helpers for the unified trading service."""
+
+from __future__ import annotations
+
+from asyncio import Task, TaskGroup
+from collections import deque
+from collections.abc import Awaitable, Callable, Iterable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Deque, Dict, List, Optional
+
+from config.service_settings import TradingServiceSettings
+
+QUOTE_SUFFIXES: tuple[str, ...] = ("USDT", "USDC", "USD")
+
+
+def to_scanner_symbol(symbol: str) -> str:
+    """Convert display symbols (e.g. ``BTC/USD``) to scanner friendly format."""
+
+    return symbol.replace("/", "").upper()
+
+
+def to_display_symbol(symbol: str) -> str:
+    """Convert scanner symbols back to Alpaca display format."""
+
+    if "/" in symbol:
+        return symbol
+
+    upper_symbol = symbol.upper()
+    for suffix in QUOTE_SUFFIXES:
+        if upper_symbol.endswith(suffix):
+            base = upper_symbol[: -len(suffix)]
+            return f"{base}/{suffix}"
+
+    if len(upper_symbol) > 3:
+        return f"{upper_symbol[:-3]}/{upper_symbol[-3:]}"
+
+    return upper_symbol
+
+
+@dataclass
+class SessionMetrics:
+    """Track win rates and profitability metrics for the session."""
+
+    session_start: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    total_profit: float = 0.0
+    total_trades: int = 0
+    winning_trades: int = 0
+    losing_trades: int = 0
+    current_streak: int = 0
+    best_streak: int = 0
+    trades_per_hour: float = 0.0
+    avg_profit_per_trade: float = 0.0
+    win_rate: float = 0.0
+
+    def update_on_trade(self, trade: Dict[str, Any]) -> None:
+        """Update win/loss ratios and derived metrics for a completed trade."""
+
+        self.total_trades += 1
+        profit = trade.get("profit")
+        if profit is not None:
+            self.total_profit += profit
+            if profit > 0:
+                self.winning_trades += 1
+                self.current_streak = max(0, self.current_streak) + 1
+                self.best_streak = max(self.best_streak, self.current_streak)
+            else:
+                self.losing_trades += 1
+                self.current_streak = min(0, self.current_streak) - 1
+
+        hours_elapsed = max(
+            0.1,
+            (datetime.now(timezone.utc) - self.session_start).total_seconds() / 3600,
+        )
+        self.trades_per_hour = self.total_trades / hours_elapsed
+
+        if self.total_trades > 0:
+            self.avg_profit_per_trade = self.total_profit / self.total_trades
+            completed_trades = self.winning_trades + self.losing_trades
+            if completed_trades > 0:
+                self.win_rate = self.winning_trades / completed_trades
+
+
+@dataclass
+class TradingState:
+    """Aggregate caches and runtime state for the trading service."""
+
+    settings: TradingServiceSettings
+    alpaca_api: Optional[Any] = None
+    account_cache: Dict[str, Any] = field(default_factory=dict)
+    positions_cache: List[Any] = field(default_factory=list)
+    orders_cache: List[Any] = field(default_factory=list)
+    crypto_metrics: Dict[str, Any] = field(default_factory=dict)
+    top_movers: List[Any] = field(default_factory=list)
+    error_log: Deque[Any] = field(default_factory=lambda: deque(maxlen=100))
+    last_update: Dict[str, datetime] = field(default_factory=dict)
+    auto_trading_enabled: bool = False
+    trade_history: Deque[Dict[str, Any]] = field(default_factory=lambda: deque(maxlen=500))
+    position_entry_prices: Dict[str, float] = field(default_factory=dict)
+    session_metrics: SessionMetrics = field(default_factory=SessionMetrics)
+    current_positions: Dict[str, Any] = field(default_factory=dict)
+    current_prices: Dict[str, float] = field(default_factory=dict)
+    signals: List[Any] = field(default_factory=list)
+    crypto_scanner: Any = None
+    active_scalp_positions: Dict[str, Any] = field(default_factory=dict)
+    crypto_symbols: List[str] = field(init=False)
+    crypto_metadata: Dict[str, Dict[str, str]] = field(init=False)
+    crypto_symbol_prefixes: List[str] = field(init=False)
+    crypto_scanner_symbols: List[str] = field(default_factory=list)
+    max_concurrent_positions: int = field(init=False)
+    daily_loss_limit: float = field(init=False)
+    current_daily_loss: float = 0.0
+    background_tasks: List[Task[Any]] = field(default_factory=list)
+    background_task_group: Optional[TaskGroup] = None
+
+    def __post_init__(self) -> None:
+        self.crypto_symbols = list(self.settings.crypto_symbols)
+        self.crypto_metadata = dict(self.settings.crypto_metadata)
+        self.crypto_symbol_prefixes = [symbol.replace("/", "") for symbol in self.crypto_symbols]
+        self.max_concurrent_positions = self.settings.max_concurrent_positions
+        self.daily_loss_limit = self.settings.daily_loss_limit
+
+
+def refresh_scanner_symbols(state: TradingState) -> List[str]:
+    """Synchronise cached scanner symbols with the active strategy."""
+
+    if not state.crypto_scanner:
+        return state.crypto_scanner_symbols
+
+    enabled_symbols = state.crypto_scanner.get_enabled_symbols()
+    if not enabled_symbols:
+        state.crypto_scanner_symbols = []
+        return state.crypto_scanner_symbols
+
+    state.crypto_scanner_symbols = sorted(
+        {to_display_symbol(symbol) for symbol in enabled_symbols}
+    )
+    return state.crypto_scanner_symbols
+
+
+BackgroundWorker = Callable[[TradingState], Awaitable[Any]]
+
+
+@asynccontextmanager
+async def manage_background_tasks(
+    state: TradingState,
+    workers: Iterable[BackgroundWorker],
+) -> None:
+    """Run background workers inside a shared ``TaskGroup``.
+
+    The helper keeps ``TradingState.background_tasks`` in sync so FastAPI
+    extensions can introspect active jobs and ensures tasks are cancelled and
+    awaited before the application shuts down.
+    """
+
+    async with TaskGroup() as task_group:
+        state.background_task_group = task_group
+        tasks = state.background_tasks
+        tasks.clear()
+
+        try:
+            for worker in workers:
+                coroutine = worker(state)
+                tasks.append(
+                    task_group.create_task(
+                        coroutine,
+                        name=getattr(worker, "__name__", "background_worker"),
+                    )
+                )
+
+            yield
+        finally:
+            for task in tasks:
+                task.cancel()
+
+            tasks.clear()
+            state.background_task_group = None
+
+
+__all__ = [
+    "QUOTE_SUFFIXES",
+    "SessionMetrics",
+    "TradingState",
+    "manage_background_tasks",
+    "refresh_scanner_symbols",
+    "to_display_symbol",
+    "to_scanner_symbol",
+]

--- a/tests/unit/config/test_service_settings.py
+++ b/tests/unit/config/test_service_settings.py
@@ -1,0 +1,133 @@
+
+"""Contract tests for ``config.service_settings`` parsing semantics."""
+
+import json
+
+import pytest
+
+from config.environment import get_environment_config
+from config.service_settings import (
+    DEFAULT_CACHE_REFRESH_SECONDS,
+    DEFAULT_CRYPTO_SYMBOLS,
+    DEFAULT_DAILY_LOSS_LIMIT,
+    DEFAULT_MAX_CONCURRENT_POSITIONS,
+    DEFAULT_SCALPER_COOLDOWN_SECONDS,
+    DEFAULT_SCALPER_POLL_SECONDS,
+    DEFAULT_SCANNER_INTERVAL_SECONDS,
+    get_service_settings,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_caches():
+    """Ensure each test observes a fresh configuration instance."""
+
+    get_environment_config.cache_clear()
+    get_service_settings.cache_clear()
+    yield
+    get_environment_config.cache_clear()
+    get_service_settings.cache_clear()
+
+
+def test_get_service_settings_defaults(monkeypatch, tmp_path):
+    """When no overrides are set the defaults should be returned."""
+
+    # Explicitly remove any environment variables that could interfere.
+    for variable in [
+        "TRADING_RUNTIME_ENV",
+        "APCA_API_KEY_ID",
+        "APCA_API_SECRET_KEY",
+        "APCA_API_BASE_URL",
+        "ALPACA_AUTH_FILE",
+        "TRADING_SERVICE_CRYPTO_SYMBOLS",
+        "TRADING_SERVICE_CACHE_REFRESH_SECONDS",
+        "TRADING_SERVICE_SCALPER_POLL_SECONDS",
+        "TRADING_SERVICE_SCALPER_COOLDOWN_SECONDS",
+        "TRADING_SERVICE_MAX_CONCURRENT_POSITIONS",
+        "TRADING_SERVICE_DAILY_LOSS_LIMIT",
+        "TRADING_SERVICE_CRYPTO_SCANNER_INTERVAL_SECONDS",
+        "TRADING_SERVICE_CRYPTO_METADATA",
+    ]:
+        monkeypatch.delenv(variable, raising=False)
+
+    auth_path = tmp_path / "auth.txt"
+    monkeypatch.setenv("ALPACA_AUTH_FILE", str(auth_path))
+
+    settings = get_service_settings()
+
+    assert settings.crypto_symbols == DEFAULT_CRYPTO_SYMBOLS
+    assert settings.cache_refresh_seconds == DEFAULT_CACHE_REFRESH_SECONDS
+    assert settings.scalper_poll_interval_seconds == DEFAULT_SCALPER_POLL_SECONDS
+    assert settings.scalper_cooldown_seconds == DEFAULT_SCALPER_COOLDOWN_SECONDS
+    assert settings.max_concurrent_positions == DEFAULT_MAX_CONCURRENT_POSITIONS
+    assert settings.daily_loss_limit == DEFAULT_DAILY_LOSS_LIMIT
+    assert settings.crypto_scanner_interval_seconds == DEFAULT_SCANNER_INTERVAL_SECONDS
+    assert settings.crypto_metadata.keys() == set(DEFAULT_CRYPTO_SYMBOLS)
+    assert settings.enabled_background_workers is None
+
+    assert settings.alpaca.auth_file == auth_path
+    assert settings.alpaca.api_key is None
+    assert settings.alpaca.api_secret is None
+    assert "alpaca.markets" in settings.alpaca.api_base_url
+
+
+def test_get_service_settings_environment_overrides(monkeypatch, tmp_path):
+    """Environment variables should override the default configuration."""
+
+    monkeypatch.setenv("TRADING_RUNTIME_ENV", "production")
+    monkeypatch.setenv("APCA_API_KEY_ID", "unit-test-key")
+    monkeypatch.setenv("APCA_API_SECRET_KEY", "unit-test-secret")
+    monkeypatch.setenv("APCA_API_BASE_URL", "https://example.com")
+
+    auth_path = tmp_path / "overrides.json"
+    monkeypatch.setenv("ALPACA_AUTH_FILE", str(auth_path))
+
+    monkeypatch.setenv(
+        "TRADING_SERVICE_CRYPTO_SYMBOLS",
+        json.dumps(["BTC/USD", "ETH/USD"]),
+    )
+    monkeypatch.setenv("TRADING_SERVICE_CACHE_REFRESH_SECONDS", "7")
+    monkeypatch.setenv("TRADING_SERVICE_SCALPER_POLL_SECONDS", "11")
+    monkeypatch.setenv("TRADING_SERVICE_SCALPER_COOLDOWN_SECONDS", "19")
+    monkeypatch.setenv("TRADING_SERVICE_MAX_CONCURRENT_POSITIONS", "4")
+    monkeypatch.setenv("TRADING_SERVICE_DAILY_LOSS_LIMIT", "123.45")
+    monkeypatch.setenv("TRADING_SERVICE_CRYPTO_SCANNER_INTERVAL_SECONDS", "23")
+    monkeypatch.setenv(
+        "TRADING_SERVICE_CRYPTO_METADATA",
+        json.dumps(
+            {
+                "BTC/USD": {"name": "Bitcoin", "exchange": "CBSE"},
+                "ETH/USD": {"name": "Ethereum", "exchange": "FTXU"},
+            }
+        ),
+    )
+    monkeypatch.setenv(
+        "TRADING_SERVICE_BACKGROUND_WORKERS",
+        "update_cache,crypto_scalper",
+    )
+
+    settings = get_service_settings()
+
+    assert settings.crypto_symbols == ["BTC/USD", "ETH/USD"]
+    assert settings.cache_refresh_seconds == 7
+    assert settings.scalper_poll_interval_seconds == 11
+    assert settings.scalper_cooldown_seconds == 19
+    assert settings.max_concurrent_positions == 4
+    assert settings.daily_loss_limit == 123.45
+    assert settings.crypto_scanner_interval_seconds == 23
+    assert settings.crypto_metadata["BTC/USD"]["exchange"] == "CBSE"
+    assert settings.crypto_metadata["ETH/USD"]["name"] == "Ethereum"
+    assert settings.enabled_background_workers == ["update_cache", "crypto_scalper"]
+
+    assert settings.alpaca.auth_file == auth_path
+    assert settings.alpaca.api_key == "unit-test-key"
+    assert settings.alpaca.api_secret == "unit-test-secret"
+    assert settings.alpaca.api_base_url == "https://example.com"
+
+
+def test_background_worker_env_handles_blank_values(monkeypatch):
+    monkeypatch.setenv("TRADING_SERVICE_BACKGROUND_WORKERS", "   ")
+
+    settings = get_service_settings()
+
+    assert settings.enabled_background_workers == []

--- a/tests/unit/services/unified_trading/test_background_workers.py
+++ b/tests/unit/services/unified_trading/test_background_workers.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from services.unified_trading import (
+    list_named_background_workers,
+    list_background_workers,
+    register_background_worker,
+    resolve_background_workers,
+    reset_background_workers,
+    set_background_workers,
+)
+
+
+@pytest.fixture()
+def registry_snapshot() -> None:
+    """Snapshot and restore the worker registry for each test."""
+
+    original_workers = list_background_workers()
+    yield
+    set_background_workers(original_workers)
+
+
+async def _dummy_worker(state) -> None:  # pragma: no cover - exercised via registry
+    return None
+
+
+def _worker_names() -> List[str]:
+    return [worker.__name__ for worker in list_background_workers()]
+
+
+def test_default_workers_are_registered_in_order(registry_snapshot) -> None:
+    pytest.importorskip("alpaca_trade_api")
+    import unified_trading_service_with_frontend  # noqa: F401
+
+    reset_background_workers()
+    import importlib
+
+    importlib.reload(unified_trading_service_with_frontend)
+    names = _worker_names()
+    assert names[:3] == [
+        "update_cache",
+        "crypto_scanner",
+        "crypto_scalping_trader",
+    ]
+
+
+def test_register_background_worker_is_idempotent(registry_snapshot) -> None:
+    register_background_worker(_dummy_worker)
+    names = _worker_names()
+    assert names[-1] == "_dummy_worker"
+
+    register_background_worker(_dummy_worker)
+    names_after = _worker_names()
+    assert names_after.count("_dummy_worker") == 1
+
+
+def test_resolve_background_workers_filters_unknown_entries(registry_snapshot) -> None:
+    register_background_worker(_dummy_worker)
+
+    resolved = resolve_background_workers(["_dummy_worker", "missing_worker"])
+    assert [_worker.__name__ for _worker in resolved] == ["_dummy_worker"]
+
+
+def test_list_named_background_workers_exposes_names(registry_snapshot) -> None:
+    register_background_worker(_dummy_worker)
+    items = list_named_background_workers()
+
+    assert any(name == "_dummy_worker" for name, _ in items)


### PR DESCRIPTION
## Summary
- allow the runtime to start without python-dotenv while still honoring .env files when present
- add TRADING_SERVICE_BACKGROUND_WORKERS parsing, registry helpers, and FastAPI lifespan wiring so localhost runs can pick workers from the environment
- document the localhost workflow and expand unit coverage for the new configuration surfaces

## Testing
- pytest tests/unit/config/test_service_settings.py
- pytest tests/unit/services/unified_trading/test_background_workers.py

------
https://chatgpt.com/codex/tasks/task_e_68e58224a73883309293ae7567418c8f